### PR TITLE
Use the cache provided by ASIHTTPRequest.

### DIFF
--- a/QuickHubApp/GithubOAuthClient.m
+++ b/QuickHubApp/GithubOAuthClient.m
@@ -23,6 +23,7 @@
 
 #import "GithubOAuthClient.h"
 #import "ASIHTTPRequest.h"
+#import "ASIDownloadCache.h"
 #import "JSONKit.h"
 #import "Preferences.h"
 #import "Context.h"
@@ -39,6 +40,9 @@
     self = [super init];
     if (self) {
         // Initialization code here.
+        
+        // Use the default cache provided by ASIHTTPRequest
+        [ASIHTTPRequest setDefaultCache:[ASIDownloadCache sharedCache]];
     }
     
     return self;
@@ -70,6 +74,8 @@
 
 - (NSDictionary*) loadUser:(id) sender {
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:[self getOAuthURL:@"user"]]];
+    [request setCachePolicy: ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -85,6 +91,8 @@
     // FIXME : Add all param cf http://developer.github.com/v3/issues/#list-issues
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"issues"]];
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     
@@ -99,6 +107,8 @@
     // get gists
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"gists"]];
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     
@@ -113,6 +123,8 @@
     
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"user/orgs"]];
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -127,6 +139,8 @@
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:[NSString stringWithFormat:@"orgs/%@/repos", name]]];
 
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     
@@ -138,8 +152,11 @@
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"user/repos"]];
 
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
+    
     NSDictionary *result = [[request responseString] objectFromJSONString];
     // DO not release the request, it cause failures on the threads...
     //[request release];
@@ -165,7 +182,9 @@
     NSMutableSet *result = [[NSMutableSet alloc]init];
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"user/repos"]];
 
-    ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];    
+    ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     [self updateRemaining:request];
@@ -185,6 +204,9 @@
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:[NSString stringWithFormat:@"repos/%@/%@/pulls", userName, name]]];
 
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
+    
     [request startSynchronous];
     [self updateRemaining:request];
     int status = [request responseStatusCode];
@@ -201,6 +223,8 @@
     
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"user/followers"]];
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -213,6 +237,8 @@
     
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"user/following"]];
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -224,6 +250,8 @@
 - (NSDictionary *) loadWatchedRepos:(id) sender {
     NSString *url = [NSString stringWithFormat:@"%@&per_page=100", [self getOAuthURL:@"user/watched"]];
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];   
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -238,6 +266,8 @@
     NSString *url = [NSString stringWithFormat:@"%@", [self getOAuthURL:[NSString stringWithFormat:@"users/%@/events", userName]]];
     NSLog(@"%@", url);
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];   
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -252,6 +282,8 @@
     NSString *url = [NSString stringWithFormat:@"%@", [self getOAuthURL:[NSString stringWithFormat:@"users/%@/received_events", userName]]];
     
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:url]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];   
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -263,6 +295,8 @@
 // Note : this is not available with oauth!
 - (NSDictionary *) getAuthorizations:(id) sender {
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:[self getOAuthURL:@"authorizations"]]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request setDelegate:self];
     [request startSynchronous];   
     NSDictionary *result = [[request responseString] objectFromJSONString];
@@ -278,6 +312,8 @@
         
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:[self getOAuthURL:@"gists"]]];
     [request appendPostData:[payload dataUsingEncoding:NSUTF8StringEncoding]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     
     [request startSynchronous];
     [self updateRemaining:request];
@@ -389,6 +425,8 @@
 - (NSDictionary *) getGist:(NSString*)gistId {
     NSDictionary *result = nil;
     ASIHTTPRequest *request = [ASIHTTPRequest requestWithURL:[NSURL URLWithString:[self getOAuthURL:[NSString stringWithFormat:@"gists/%@", gistId]]]];
+    [request setCachePolicy:ASIAskServerIfModifiedCachePolicy | ASIFallbackToCacheIfLoadFailsCachePolicy];
+    [request setCacheStoragePolicy:ASICachePermanentlyCacheStoragePolicy];
     [request startSynchronous];
     [self updateRemaining:request];
     


### PR DESCRIPTION
To save on the rate limit that Github provides (5000 p/h) I've changed the GitHub client to use the DefaultCache that ASIHTTPRequest provides. This should if nothing has changed then the data will not be re-downloaded.

One of many pull requests on the way.
