### PR TITLE
Fixed issue with background polling thread not getting deleted.

### DIFF
--- a/QuickHubApp/AppController.h
+++ b/QuickHubApp/AppController.h
@@ -22,18 +22,14 @@
 // SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-
-#import "ASIHTTPRequest.h"
-#import "Reachability.h"
-
-#import "Preferences.h"
-#import "GithubOAuthClient.h"
 #import "MenuController.h"
-#import "EventsManager.h"
 
 @class Reachability;
-@interface AppController : NSObject {
-    
+@class EventsManager;
+@class GithubOAuthClient;
+
+@interface AppController : NSObject
+{
     GithubOAuthClient *githubController;
     EventsManager *eventsManager;
     IBOutlet MenuController *menuController;
@@ -55,6 +51,7 @@
     Reachability* hostReach;
     Reachability* internetReachable;
     
+    dispatch_semaphore_t runloopSemaphore;
 }
 
 - (void) pollIssues:(id) sender;

--- a/QuickHubApp/AppController.m
+++ b/QuickHubApp/AppController.m
@@ -23,9 +23,12 @@
 
 #import "AppController.h"
 #import "NSData+Base64.h"
-#import "ASIHTTPRequest.h"
 #import "QHConstants.h"
 #import "Context.h"
+#import "EventsManager.h"
+#import "GithubOAuthClient.h"
+#import "Reachability.h"
+#import "Preferences.h"
 
 @interface AppController (Private)
 - (void) updateGistUI:(NSDictionary *) dictionary;
@@ -45,7 +48,7 @@
 {
     self = [super init];
     if (self) {
-        githubController = [[GithubOAuthClient alloc]init];
+        githubController = [[GithubOAuthClient alloc] init];
 
         //reachability
         // check for internet connection
@@ -94,40 +97,34 @@
 
 #pragma mark - Github Actions
 
-- (void) loadAll:(id)sender {
+- (void)loadAll:(id)sender
+{
     if (!githubPolling) {
         Preferences *preferences = [Preferences sharedInstance];
         if ([[preferences oauthToken]length] == 0 || ![githubController checkCredentials:nil]) {
             return;
         }
         
-        [self performSelectorInBackground:@selector(doLoadAll:) withObject:nil];        
-
+        githubPolling = YES;
+        [self performSelectorInBackground:@selector(doLoadAll:) withObject:nil];
     } else {
-        //NSLog(@"Can not start all since we are already polling...");
+        NSLog(@"Can not start all since we are already polling...");
     }
 }
 
-- (void) doLoadAll:(id) sender {
-    //NSLog(@"Load all and start polling things");
-    NSAutoreleasePool* pool = [[NSAutoreleasePool alloc] init];
-    NSRunLoop* runLoop = [NSRunLoop currentRunLoop];
+- (void) doLoadAll:(id) sender
+{
+    NSLog(@"Load all and start polling things");
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     
-    gistTimer = [NSTimer scheduledTimerWithTimeInterval:240 target:self selector:@selector(pollGists:) userInfo:nil repeats:YES];
-    
-    repositoryTimer = [NSTimer scheduledTimerWithTimeInterval:310 target:self selector:@selector(pollRepos:) userInfo:nil repeats:YES];
-    
-    organizationTimer = [NSTimer scheduledTimerWithTimeInterval:603 target:self selector:@selector(pollOrgs:) userInfo:nil repeats:YES];
-    
-    issueTimer = [NSTimer scheduledTimerWithTimeInterval:145 target:self selector:@selector(pollIssues:) userInfo:nil repeats:YES];
-    
-    followTimer = [NSTimer scheduledTimerWithTimeInterval:3600 target:self selector:@selector(pollFollow:) userInfo:nil repeats:YES];
-    
-    watchingTimer = [NSTimer scheduledTimerWithTimeInterval:1802 target:self selector:@selector(pollWatching:) userInfo:nil repeats:YES];
-    
-    pullTimer = [NSTimer scheduledTimerWithTimeInterval:701 target:self selector:@selector(pollPulls:) userInfo:nil repeats:YES];
-    
-    eventTimer = [NSTimer scheduledTimerWithTimeInterval:30 target:self selector:@selector(pollEvents:) userInfo:nil repeats:YES];
+    gistTimer           = [NSTimer scheduledTimerWithTimeInterval:240 target:self selector:@selector(pollGists:) userInfo:nil repeats:YES];
+    repositoryTimer     = [NSTimer scheduledTimerWithTimeInterval:310 target:self selector:@selector(pollRepos:) userInfo:nil repeats:YES];
+    organizationTimer   = [NSTimer scheduledTimerWithTimeInterval:603 target:self selector:@selector(pollOrgs:) userInfo:nil repeats:YES];
+    issueTimer          = [NSTimer scheduledTimerWithTimeInterval:145 target:self selector:@selector(pollIssues:) userInfo:nil repeats:YES];
+    followTimer         = [NSTimer scheduledTimerWithTimeInterval:3600 target:self selector:@selector(pollFollow:) userInfo:nil repeats:YES];
+    watchingTimer       = [NSTimer scheduledTimerWithTimeInterval:1802 target:self selector:@selector(pollWatching:) userInfo:nil repeats:YES];
+    pullTimer           = [NSTimer scheduledTimerWithTimeInterval:701 target:self selector:@selector(pollPulls:) userInfo:nil repeats:YES];
+    eventTimer          = [NSTimer scheduledTimerWithTimeInterval:30 target:self selector:@selector(pollEvents:) userInfo:nil repeats:YES];
     
     // add the timer to the common run loop mode so that it does not freezes when the user clicks on menu
     // cf http://stackoverflow.com/questions/4622684/nsrunloop-freezes-with-nstimer-and-any-input
@@ -140,23 +137,31 @@
     [[NSRunLoop currentRunLoop] addTimer:pullTimer forMode:NSRunLoopCommonModes];
     [[NSRunLoop currentRunLoop] addTimer:eventTimer forMode:NSRunLoopCommonModes];
     
-    githubPolling = YES;
+    [repositoryTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [gistTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [organizationTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [issueTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [eventTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [followTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [watchingTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
+    [pullTimer setFireDate:[NSDate dateWithTimeIntervalSinceNow:1]];
     
-    [repositoryTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:1]];
-    [gistTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:2]];
-    [organizationTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:3]];
-    [issueTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:4]];
-    [followTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:6]];
-    [watchingTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:7]];
-    [pullTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:10]];
-    [eventTimer setFireDate: [NSDate dateWithTimeIntervalSinceNow:5]];
+    // Create a semphore so we wait until the signal is raised to exit this thread
+    runloopSemaphore = dispatch_semaphore_create(0);
     
-    [runLoop run];
+    while (dispatch_semaphore_wait(runloopSemaphore, DISPATCH_TIME_NOW)) {
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:2]];
+    }
+    
+    // Release the semaphore after finished with it
+    CFRelease(runloopSemaphore);
+    
     [pool release];
 }
 
 - (void) stopAll:(id)sender {
     if (githubPolling) {
+        githubPolling = NO;
         [gistTimer invalidate];
         [repositoryTimer invalidate];
         [organizationTimer invalidate];
@@ -166,10 +171,10 @@
         [pullTimer invalidate];
         [eventTimer invalidate];
     }
-    githubPolling = NO;
     
-    // FIXME : how to kill the background thread? Is it garbaged when there is nothing more in the run loop?
-    //NSLog(@"Stopped!");
+    // Signal for the thread to be deleted
+    dispatch_semaphore_signal(runloopSemaphore);
+    NSLog(@"Stopped!");
 }
 
 - (void) cleanCache:(id)sender {
@@ -204,19 +209,21 @@
         NSDictionary *dictionary = [githubController loadOrganizations:nil];
         // get all repository for each organization
         if (dictionary) {
-            NSMutableDictionary *dict = [[NSMutableDictionary alloc]init];
+            NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
 
             for (NSArray *org in dictionary) {
-                NSMutableDictionary *orgDictionary = [[NSMutableDictionary alloc]init];
+                NSMutableDictionary *orgDictionary = [[NSMutableDictionary alloc] init];
                 NSDictionary *repoDictionary = [githubController getReposForOrganization:[org valueForKey:@"login"]];
                 [orgDictionary setValue:repoDictionary forKey:@"repos"];
                 [orgDictionary setValue:org forKey:@"org"];
                 [dict setValue:orgDictionary forKey:[org valueForKey:@"login"]];
+                [orgDictionary release];
             }
             //dict = [orgname -> [repos->[dict], [org->[dict]]]]
             
             //[self performSelectorOnMainThread:@selector(updateOrgsUI:) withObject:dict waitUntilDone:NO];
-            [menuController organizationsFinished:dict];  
+            [menuController organizationsFinished:dict];
+            [dict release];
         }
     }
 }
@@ -317,7 +324,6 @@
    
         NetworkStatus internetStatus = [internetReachable currentReachabilityStatus];
         switch (internetStatus)
-    
         {
             case NotReachable:
             {
@@ -361,10 +367,15 @@
     }
 }
 
-- (void)dealloc {
-    [eventsManager release];
+- (void)dealloc
+{
+    [super dealloc];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+    [githubController release];
+    [internetReachable release];
+    [hostReach release];
+    [menuController release];
+    [eventsManager release];
 }
-
 
 @end


### PR DESCRIPTION
Every time the user loses connection and gets it back it spawned a new thread because calling [[NSRunLoop currentRunLoop] run] would run forever.
1. Added semaphore so when we want to stop the thread we just call dispatch_semaphore_signal.
2. Fixed memory leaks when allocating dictionaries and not releasing them.

We really need to think about the polling times....not sure what kind of approach we need to take.
